### PR TITLE
Fixed placed blocks being announced

### DIFF
--- a/src/main/java/coffee/weneed/founddiamonds/BlockCounter.java
+++ b/src/main/java/coffee/weneed/founddiamonds/BlockCounter.java
@@ -6,6 +6,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import coffee.weneed.founddiamonds.LLoc;
 import coffee.weneed.founddiamonds.file.Config;
 import coffee.weneed.founddiamonds.util.PluginUtils;
 
@@ -68,7 +69,7 @@ public class BlockCounter {
 		if (fd.getConfig().getBoolean(Config.mysqlEnabled))
 			return !fd.getMySQL().blockWasPlaced(loc) && !wasCounted(loc);
 		else
-			return !wasCounted(loc) && !fd.getBlockPlaceListener().getFlatFilePlacedBlocks().contains(loc);
+			return !wasCounted(loc) && !fd.getBlockPlaceListener().getFlatFilePlacedBlocks().contains(new LLoc(loc));
 	}
 
 	public void removeAnnouncedOrPlacedBlock(final Location loc) {


### PR DESCRIPTION
Currently there is a bug which causes blocks that were placed by players to still be counted and be announced. 
This was caused by the function `isAnnounceable` which checks if the hashset contains the location.
https://github.com/WeNeedCoffee/FoundDiamonds/blob/3485c689520e76628932a13dbaf0c895b77e6394/src/main/java/coffee/weneed/founddiamonds/BlockCounter.java#L67
However the hashset was stored as the plugins internal "LLoc" class, but it was checking it as Bukkits Location class as returned by the event. 
This PR makes it first convert the Location to a LLoc before checking, this fixes the issue.